### PR TITLE
Fixed arm64 build error for m1 mac

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   node:
     build: .
+    platform: linux/x86_64
     tty: true
     ports:
       - "0.0.0.0:5001:3000"
@@ -14,6 +15,8 @@ services:
     networks:
       - default
       - sample-shared
+    environment:
+      npm_config_target_arch: x64
 networks:
   sample-shared:
     external: true


### PR DESCRIPTION
## Change Log
- アーキテクチャの違いでx64のコンパイルができないことがある
    - `response status 404 Not Found on https://node-precompiled-binaries.grpc.io/grpc-tools/v1.11.2/linux-arm64.tar.gz`